### PR TITLE
Add Poison dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ def project do
 end
 ```
 
-You also need to add the transport library (for example a websocket client) as a dependency. Out of the box, the adapter for [sanmiguel/websocket_client](https://github.com/sanmiguel/websocket_client) is provided, but you still need to include the library yourself:
+You also need to add the transport (e.g. a websocket client), and serializer (e.g. JSON) as dependencies. Out of the box, the adapter for [sanmiguel/websocket_client](https://github.com/sanmiguel/websocket_client), and support for [devinus/poison](https://github.com/devinus/poison) is provided but you still need to include the libraries yourself:
 
 ```elixir
 def project do
   [
     deps: [
       {:websocket_client, github: "sanmiguel/websocket_client", tag: "1.1.0"},
+      {:poison, "~> 1.5.2"}
+
       # ...
     ],
     application: [


### PR DESCRIPTION
I realized that Poison is being used in the default [JSON Serializer](https://github.com/Aircloak/phoenix_gen_socket_client/blob/b27d35ecdf2c27d3d4a9caabaeb196ce6546caf8/lib/gen_socket_client/serializer.ex) but not being listed in the dependencies. I guess most of the use cases for this library already include Poison indirectly from other libraries (e.g. Phoenix), so this wasn't documented.