### PR TITLE
Add heartbeat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ GenSocketClient.start_link(
   callback_module,
   transport_module,
   arbitrary_argument,
-  socket_opts, # defaults to []
+  socket_opts, # defaults to [heartbeat: 30_000]
   gen_server_opts # defaults to []
 )
 ```

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -72,7 +72,8 @@ defmodule Phoenix.Channels.GenSocketClient do
   @type transport_opts :: any
   @type socket_opts :: [
     serializer: module,
-    transport_opts: transport_opts
+    transport_opts: transport_opts,
+    heartbeat: integer | nil
   ]
   @type callback_state :: any
   @opaque transport :: %{
@@ -156,8 +157,8 @@ defmodule Phoenix.Channels.GenSocketClient do
   def push(transport, topic, event, payload) do
     ref = next_ref(topic, transport.message_refs)
     cond do
-      # first message on a channel must always be a join
-      event != "phx_join" and ref == 1 ->
+      # first message on a channel must always be a join except for system messages (heartbeat)
+      event != "phx_join" and ref == 1 and topic != "phoenix" ->
         :ets.delete(transport.message_refs, topic)
         {:error, :not_joined}
       # join must always be a first message
@@ -205,6 +206,7 @@ defmodule Phoenix.Channels.GenSocketClient do
             transport_mod: transport_mod,
             transport_opts: Keyword.get(socket_opts, :transport_opts, []),
             serializer: Keyword.get(socket_opts, :serializer, Phoenix.Channels.GenSocketClient.Serializer.Json),
+            heartbeat: Keyword.get(socket_opts, :heartbeat, 30_000),
             callback: callback,
             callback_state: callback_state,
             transport_pid: nil,
@@ -226,6 +228,12 @@ defmodule Phoenix.Channels.GenSocketClient do
   def handle_cast({:notify_message, encoded_message}, state) do
     decoded_message = state.serializer.decode_message(encoded_message)
     handle_message(decoded_message, state)
+  end
+
+  def handle_info(:heartbeat, %{heartbeat: heartbeat} = state) do
+    push(transport(state), "phoenix", "heartbeat", %{})
+    :erlang.send_after(heartbeat, self(), :heartbeat)
+    {:noreply, state}
   end
 
   @doc false
@@ -277,9 +285,10 @@ defmodule Phoenix.Channels.GenSocketClient do
   defp maybe_connect(:connect, state), do: connect(state)
   defp maybe_connect(:noconnect, state), do: state
 
-  defp connect(%{transport_pid: nil} = state) do
+  defp connect(%{transport_pid: nil, heartbeat: heartbeat} = state) do
     {:ok, transport_pid} = state.transport_mod.start_link(state.url, state.transport_opts)
     transport_mref = Process.monitor(transport_pid)
+    if (heartbeat != nil), do: :erlang.send_after(heartbeat, self(), :heartbeat)
     %{state | transport_pid: transport_pid, transport_mref: transport_mref}
   end
 

--- a/lib/gen_socket_client/test_socket.ex
+++ b/lib/gen_socket_client/test_socket.ex
@@ -115,7 +115,7 @@ defmodule Phoenix.Channels.GenSocketClient.TestSocket do
 
   @doc "Awaits a message from the socket."
   @spec await_message(GenServer.server, GenServer.timeout) ::
-    {:ok, GenSocketClient.topic, GenSocketClient.event, GenSocketClient.payload} | {:error, :timeout}
+    {:ok, GenSocketClient.payload} | {:error, :timeout}
   def await_message(socket, timeout \\ 5000) do
     receive do
       {^socket, :message, message} -> {:ok, message}
@@ -124,6 +124,17 @@ defmodule Phoenix.Channels.GenSocketClient.TestSocket do
     end
   end
 
+
+  @doc "Awaits a reply from the socket."
+  @spec await_reply(GenServer.server, GenServer.timeout) ::
+    {:ok, GenSocketClient.topic, GenSocketClient.event, GenSocketClient.payload} | {:error, :timeout}
+  def await_reply(socket, timeout \\ 5000) do
+    receive do
+      {^socket, :reply, topic, ref, payload} -> {:ok, topic, ref, payload}
+    after timeout ->
+      {:error, :timeout}
+    end
+  end
 
   # -------------------------------------------------------------------
   # Channels.Client.GenSocketClient callbacks

--- a/test/socket_client_test.exs
+++ b/test/socket_client_test.exs
@@ -145,6 +145,19 @@ defmodule Phoenix.Channels.GenSocketClientTest do
         end)
   end
 
+  test "sends heartbeat messages" do
+    {:ok, socket} = start_socket(url, true, [heartbeat: 100])
+    assert :connected == TestSocket.wait_connect_status(socket)
+    assert {:ok, "phoenix", 2, %{"response" => %{}, "status" => "ok"}} == TestSocket.await_reply(socket, 500)
+    assert {:ok, "phoenix", 3, %{"response" => %{}, "status" => "ok"}} == TestSocket.await_reply(socket, 500)
+  end
+
+  test "disable heartbeat messages" do
+    {:ok, socket} = start_socket(url, true, [heartbeat: nil])
+    assert :connected == TestSocket.wait_connect_status(socket)
+    assert {:error, :timeout} == TestSocket.await_reply(socket, 500)
+  end
+
   defp join_channel do
     assert {:ok, socket} = start_socket()
     assert :connected == TestSocket.wait_connect_status(socket)
@@ -154,8 +167,8 @@ defmodule Phoenix.Channels.GenSocketClientTest do
     %{socket: socket, server_channel: server_channel}
   end
 
-  defp start_socket(url \\ url(), connect \\ true) do
-    TestSocket.start_link(Phoenix.Channels.GenSocketClient.Transport.WebSocketClient, url, connect)
+  defp start_socket(url \\ url(), connect \\ true, socket_opts \\ []) do
+    TestSocket.start_link(Phoenix.Channels.GenSocketClient.Transport.WebSocketClient, url, connect, socket_opts)
   end
 
   defp url(params \\ %{shared_secret: "supersecret"}) do


### PR DESCRIPTION
The heartbeat interval can be configured in the socket_opts, it is
measured in milliseconds. If set to `nil`, heartbeat messages will not
be sent.