### PR TITLE
suppress logging of socket termination

### DIFF
--- a/lib/gen_socket_client/transport/web_socket_client.ex
+++ b/lib/gen_socket_client/transport/web_socket_client.ex
@@ -72,7 +72,5 @@ defmodule Phoenix.Channels.GenSocketClient.Transport.WebSocketClient do
   end
 
   @doc false
-  def websocket_terminate(reason, _req, _state) do
-    Logger.info(fn -> "Websocket connection closed with reason #{inspect reason}" end)
-  end
+  def websocket_terminate(_reason, _req, _state), do: :ok
 end


### PR DESCRIPTION
This logging just produces noise. If the client socket want's to notice termination, it can trap exits, in which case a termination is converted into a disconnect event, and the corresponding reason is sent.