### PR TITLE
don't attempt to connect from when callback returns :stop

### DIFF
--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -306,5 +306,5 @@ defmodule Phoenix.Channels.GenSocketClient do
   defp handle_callback_response({:connect, callback_state}, state),
     do: {:noreply, connect(%{state | callback_state: callback_state})}
   defp handle_callback_response({:stop, reason, callback_state}, state),
-    do: {:stop, reason, connect(%{state | callback_state: callback_state})}
+    do: {:stop, reason, %{state | callback_state: callback_state}}
 end


### PR DESCRIPTION
I'm guessing attempting to connect from the `{:stop, reason, state}` handler was a copy + paste error? Attempting to do so actually causes a crash, at least from an already-connected process.