### PR TITLE
Stop crashing on encoding errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- Serialization failures are propagated as tuples instead of exceptions
+
 ## 1.1.1
 
 - Changed the internals to simplify creating a large number of open connections.

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -178,9 +178,12 @@ defmodule Phoenix.Channels.GenSocketClient do
       event == "phx_join" and ref > 1 ->
         {:error, :already_joined}
       true ->
-        frame = transport.serializer.encode_message(%{topic: topic, event: event, payload: payload, ref: ref})
-        transport.transport_mod.push(transport.transport_pid, frame)
-        {:ok, ref}
+        case transport.serializer.encode_message(%{topic: topic, event: event, payload: payload, ref: ref}) do
+          {:ok, encoded} ->
+            transport.transport_mod.push(transport.transport_pid, encoded)
+            {:ok, ref}
+          error -> error
+        end
     end
   end
 

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -182,7 +182,7 @@ defmodule Phoenix.Channels.GenSocketClient do
           {:ok, encoded} ->
             transport.transport_mod.push(transport.transport_pid, encoded)
             {:ok, ref}
-          _error -> {:error, :encoding_error}
+          {:error, error} -> {:error, {:encoding_error, error}}
         end
     end
   end

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -182,7 +182,7 @@ defmodule Phoenix.Channels.GenSocketClient do
           {:ok, encoded} ->
             transport.transport_mod.push(transport.transport_pid, encoded)
             {:ok, ref}
-          error -> error
+          _error -> {:error, :encoding_error}
         end
     end
   end

--- a/lib/gen_socket_client/serializer.ex
+++ b/lib/gen_socket_client/serializer.ex
@@ -9,7 +9,8 @@ defmodule Phoenix.Channels.GenSocketClient.Serializer do
   @callback decode_message(GenSocketClient.encoded_message) :: GenSocketClient.message
 
   @doc "Invoked to encode a socket message."
-  @callback encode_message(GenSocketClient.message) :: Phoenix.Channels.GenSocketClient.Transport.frame
+  @callback encode_message(GenSocketClient.message) ::
+    {:ok, Phoenix.Channels.GenSocketClient.Transport.frame} | {:error, reason :: any}
 end
 
 defmodule Phoenix.Channels.GenSocketClient.Serializer.Json do
@@ -31,7 +32,10 @@ defmodule Phoenix.Channels.GenSocketClient.Serializer.Json do
 
   @doc false
   def encode_message(message) do
-    {:binary, Poison.encode!(message)}
+    case Poison.encode(message) do
+      {:ok, encoded} -> {:ok, {:binary, encoded}}
+      error -> error
+    end
   end
 end
 
@@ -56,6 +60,9 @@ defmodule Phoenix.Channels.GenSocketClient.Serializer.GzipJson do
 
   @doc false
   def encode_message(message) do
-    {:binary, message |> Poison.encode_to_iodata!() |> :zlib.gzip}
+    case Poison.encode_to_iodata(message) do
+      {:ok, encoded} -> {:ok, {:binary, :zlib.gzip(encoded)}}
+      error -> error
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Phoenix.GenSocketClient.Mixfile do
   use Mix.Project
 
-  @version "1.1.1"
+  @version "1.2.0"
   @github_url "https://github.com/Aircloak/phoenix_gen_socket_client"
 
   def project do

--- a/test/socket_client_test.exs
+++ b/test/socket_client_test.exs
@@ -44,7 +44,7 @@ defmodule Phoenix.Channels.GenSocketClientTest do
 
   test "sending a mesasge that cannot be encoded" do
     conn = join_channel()
-    assert {:error, {:invalid, <<166>>}} =
+    assert {:error, :encoding_error} =
       TestSocket.push_sync(conn.socket, "channel:1", "sync_event", %{"foo" => _invalid_string = <<166>>})
   end
 

--- a/test/socket_client_test.exs
+++ b/test/socket_client_test.exs
@@ -44,7 +44,7 @@ defmodule Phoenix.Channels.GenSocketClientTest do
 
   test "sending a mesasge that cannot be encoded" do
     conn = join_channel()
-    assert {:error, :encoding_error} =
+    assert {:error, {:encoding_error, {:invalid, <<166>>}}} =
       TestSocket.push_sync(conn.socket, "channel:1", "sync_event", %{"foo" => _invalid_string = <<166>>})
   end
 

--- a/test/socket_client_test.exs
+++ b/test/socket_client_test.exs
@@ -42,6 +42,12 @@ defmodule Phoenix.Channels.GenSocketClientTest do
     assert %{"status" => "ok", "response" => %{"foo" => "bar"}} = payload
   end
 
+  test "sending a mesasge that cannot be encoded" do
+    conn = join_channel()
+    assert {:error, {:invalid, <<166>>}} =
+      TestSocket.push_sync(conn.socket, "channel:1", "sync_event", %{"foo" => _invalid_string = <<166>>})
+  end
+
   test "client message receive" do
     conn = join_channel()
     send(conn.server_channel, {:push, "some_event", %{"foo" => "bar"}})


### PR DESCRIPTION
To complete https://github.com/Aircloak/aircloak/issues/1700 it would be much easier if you could get the error as a tuple instead of the having to rescue - @sasa1977 WDYT?