### PR TITLE
add GenSocketClient.topic_status/1 function (and tests) to query the …

### DIFF
--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -187,7 +187,7 @@ defmodule Phoenix.Channels.GenSocketClient do
     end
   end
 
-  @doc "Get status of topic. returns :joined or :not_joined"
+  @doc "Get status of topic. Returns true or false."
   @spec joined?(topic) :: boolean
   def joined?(topic) do
     case join_ref(topic) do

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -188,13 +188,13 @@ defmodule Phoenix.Channels.GenSocketClient do
   end
 
   @doc "Get status of topic. returns :joined or :not_joined"
-  @spec topic_status(topic) :: :joined | :not_joined
-  def topic_status(topic) do
+  @spec joined?(topic) :: boolean
+  def joined?(topic) do
     case join_ref(topic) do
       nil ->
-        :not_joined
+        false
       _ ->
-        :joined
+        true
     end
   end
 

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -187,6 +187,18 @@ defmodule Phoenix.Channels.GenSocketClient do
     end
   end
 
+  @doc "Get status of topic. returns :joined or :not_joined"
+  @spec topic_status(topic) :: :joined | :not_joined
+  def topic_status(topic) do
+    case join_ref(topic) do
+      nil ->
+        :not_joined
+      _ ->
+        :joined
+    end
+  end
+
+
   @doc "Can be invoked to send a response to the client."
   @spec reply(GenServer.from, any) :: :ok
   defdelegate reply(from, response), to: GenServer

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -187,7 +187,7 @@ defmodule Phoenix.Channels.GenSocketClient do
     end
   end
 
-  @doc "Get status of topic. Returns true or false."
+  @doc "Get the status of a topic. Returns true or false."
   @spec joined?(topic) :: boolean
   def joined?(topic) do
     case join_ref(topic) do

--- a/lib/gen_socket_client/test_socket.ex
+++ b/lib/gen_socket_client/test_socket.ex
@@ -118,9 +118,9 @@ defmodule Phoenix.Channels.GenSocketClient.TestSocket do
   end
 
   @doc "queries the status of a topic."
-  @spec topic_status(GenServer.server, GenSocketClient.topic) :: :joined | :not_joined
-  def topic_status(socket, topic) do
-    GenSocketClient.call(socket, {:topic_status, topic})
+  @spec joined?(GenServer.server, GenSocketClient.topic) :: boolean
+  def joined?(socket, topic) do
+    GenSocketClient.call(socket, {:joined?, topic})
   end
 
 
@@ -200,8 +200,8 @@ defmodule Phoenix.Channels.GenSocketClient.TestSocket do
   end
 
   @doc false
-  def handle_call({:topic_status, topic}, _from, _transport, client) do
-    topic_status_result = GenSocketClient.topic_status(topic)
-    {:reply, topic_status_result, client}
+  def handle_call({:joined?, topic}, _from, _transport, client) do
+    result = GenSocketClient.joined?(topic)
+    {:reply, result, client}
   end
 end

--- a/lib/gen_socket_client/test_socket.ex
+++ b/lib/gen_socket_client/test_socket.ex
@@ -117,6 +117,12 @@ defmodule Phoenix.Channels.GenSocketClient.TestSocket do
     end
   end
 
+  @doc "queries the status of a topic."
+  @spec topic_status(GenServer.server, GenSocketClient.topic) :: :joined | :not_joined
+  def topic_status(socket, topic) do
+    GenSocketClient.call(socket, {:topic_status, topic})
+  end
+
 
   # -------------------------------------------------------------------
   # Channels.Client.GenSocketClient callbacks
@@ -191,5 +197,11 @@ defmodule Phoenix.Channels.GenSocketClient.TestSocket do
   def handle_call({:push, topic, event, payload}, _from, transport, client) do
     push_result = GenSocketClient.push(transport, topic, event, payload)
     {:reply, push_result, client}
+  end
+
+  @doc false
+  def handle_call({:topic_status, topic}, _from, _transport, client) do
+    topic_status_result = GenSocketClient.topic_status(topic)
+    {:reply, topic_status_result, client}
   end
 end

--- a/test/socket_client_test.exs
+++ b/test/socket_client_test.exs
@@ -162,12 +162,12 @@ defmodule Phoenix.Channels.GenSocketClientTest do
 
   test "get status of joined channel" do
     conn = join_channel()
-    assert TestSocket.topic_status(conn.socket, "channel:1") == :joined
+    assert TestSocket.joined?(conn.socket, "channel:1") == true
   end
 
   test "get status of not joined channel" do
     conn = join_channel()
-    assert TestSocket.topic_status(conn.socket, "channel:2") == :not_joined
+    assert TestSocket.joined?(conn.socket, "channel:2") == :false
   end
 
   defp join_channel do

--- a/test/socket_client_test.exs
+++ b/test/socket_client_test.exs
@@ -160,6 +160,16 @@ defmodule Phoenix.Channels.GenSocketClientTest do
         end)
   end
 
+  test "get status of joined channel" do
+    conn = join_channel()
+    assert TestSocket.topic_status(conn.socket, "channel:1") == :joined
+  end
+
+  test "get status of not joined channel" do
+    conn = join_channel()
+    assert TestSocket.topic_status(conn.socket, "channel:2") == :not_joined
+  end
+
   defp join_channel do
     assert {:ok, socket} = start_socket()
     assert :connected == TestSocket.wait_connect_status(socket)


### PR DESCRIPTION
I had a need to query the status of a topic, without actually sending a ping to the server. Querying the process dictionary to get the value of the `join_ref` in my socket module would work, but means leaking "private" knowledge of `phoenix_gen_socket_client` internals into the callback module.

So I added a very simple `GenSocketClient.topic_status/1` function, which queries the `join_ref`  and returns either `:joined` or `:not_joined`.

This allows me to check the status of a topic, while keeping the knowledge of how to query the process dictionary in the `phoenix_gen_socket_client` where it belongs.

Also added tests.