### PR TITLE
add support for returning {:connect, url, query_params, state} from a…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ If the connection is not established (or dropped), you can reconnect from `handl
 
 You may also decide to defer connecting to a later point in time by returning `{:noconnect, url, query_params, state}` from the `init/1` callback. To later establish a connection you need to send some message to the socket process, and handle that message in `handle_info` by returning the `{:connect, state}` tuple.
 
+You may also return `{:connect, url, query_params, state}` from a `handle_info` callback to connect (or reconnect) the socket to a different location or with different params than it started with.
+
+
 Though somewhat elaborate, this approach has following benefits:
 
 1. The socket process starts immediately without waiting for the connection to be established.

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -418,10 +418,12 @@ defmodule Phoenix.Channels.GenSocketClient do
     do: {:noreply, connect(%{state | callback_state: callback_state})}
 
   defp handle_callback_response({:connect, url, query_params, callback_state}, state) do
-    state = state
-    |> Map.put( :callback_state, callback_state )
-    |> Map.put( :url, url )
-    |> Map.put( :query_params, Enum.uniq_by(query_params ++ [{"vsn", "2.0.0"}], &elem(&1, 0)) )
+    state =
+      state
+      |> Map.put(:callback_state, callback_state)
+      |> Map.put(:url, url)
+      |> Map.put(:query_params, Enum.uniq_by(query_params ++ [{"vsn", "2.0.0"}], &elem(&1, 0)))
+
     {:noreply, connect(state)}
   end
 

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -90,6 +90,7 @@ defmodule Phoenix.Channels.GenSocketClient do
   @type handler_response ::
           {:ok, callback_state}
           | {:connect, callback_state}
+          | {:connect, url :: String.t(), query_params, callback_state}
           | {:stop, reason :: any, callback_state}
   @type query_params :: [{String.t(), String.t()}]
 
@@ -415,6 +416,14 @@ defmodule Phoenix.Channels.GenSocketClient do
 
   defp handle_callback_response({:connect, callback_state}, state),
     do: {:noreply, connect(%{state | callback_state: callback_state})}
+
+  defp handle_callback_response({:connect, url, query_params, callback_state}, state) do
+    state = state
+    |> Map.put( :callback_state, callback_state )
+    |> Map.put( :url, url )
+    |> Map.put( :query_params, Enum.uniq_by(query_params ++ [{"vsn", "2.0.0"}], &elem(&1, 0)) )
+    {:noreply, connect(state)}
+  end
 
   defp handle_callback_response({:stop, reason, callback_state}, state),
     do: {:stop, reason, %{state | callback_state: callback_state}}

--- a/lib/gen_socket_client/test_socket.ex
+++ b/lib/gen_socket_client/test_socket.ex
@@ -219,7 +219,9 @@ defmodule Phoenix.Channels.GenSocketClient.TestSocket do
 
   @doc false
   def handle_info(:connect, _transport, client), do: {:connect, client}
-  def handle_info({:connect, url, query_params}, _transport, client), do: {:connect, url, query_params, client}
+
+  def handle_info({:connect, url, query_params}, _transport, client),
+    do: {:connect, url, query_params, client}
 
   def handle_info({:join, topic, payload}, transport, client) do
     case GenSocketClient.join(transport, topic, payload) do

--- a/lib/gen_socket_client/test_socket.ex
+++ b/lib/gen_socket_client/test_socket.ex
@@ -41,6 +41,7 @@ defmodule Phoenix.Channels.GenSocketClient.TestSocket do
     :ok
   end
 
+  @doc "Connect to the server and override/replace the initialized url and query params."
   @spec connect(GenServer.server(), String.t(), GenSocketClient.query_params()) :: :ok
   def connect(socket, url, query_params) do
     send(socket, {:connect, url, query_params})

--- a/lib/gen_socket_client/test_socket.ex
+++ b/lib/gen_socket_client/test_socket.ex
@@ -41,6 +41,12 @@ defmodule Phoenix.Channels.GenSocketClient.TestSocket do
     :ok
   end
 
+  @spec connect(GenServer.server(), String.t(), GenSocketClient.query_params()) :: :ok
+  def connect(socket, url, query_params) do
+    send(socket, {:connect, url, query_params})
+    :ok
+  end
+
   @doc "Waits until the socket is connected or disconnected"
   @spec wait_connect_status(GenServer.server(), GenServer.timeout()) ::
           :connected
@@ -213,6 +219,7 @@ defmodule Phoenix.Channels.GenSocketClient.TestSocket do
 
   @doc false
   def handle_info(:connect, _transport, client), do: {:connect, client}
+  def handle_info({:connect, url, query_params}, _transport, client), do: {:connect, url, query_params, client}
 
   def handle_info({:join, topic, payload}, transport, client) do
     case GenSocketClient.join(transport, topic, payload) do

--- a/test/socket_client_test.exs
+++ b/test/socket_client_test.exs
@@ -28,6 +28,16 @@ defmodule Phoenix.Channels.GenSocketClientTest do
     assert {:ok, {"channel:1", %{}}} == TestSocket.join(socket, "channel:1")
   end
 
+  test "connect with url and query_params" do
+    # start the socket. false means do not connect for now.
+    assert {:ok, socket} = start_socket(url(), query_params(), false)
+    refute :connected == TestSocket.wait_connect_status(socket, 100)
+    # connect by explicitly setting the url and query_params.
+    TestSocket.connect(socket, url_updated(), query_params_updated())
+    assert :connected == TestSocket.wait_connect_status(socket)
+    assert {:ok, {"channel:1", %{}}} == TestSocket.join(socket, "channel:1")
+  end
+
   test "client message push" do
     assert {:ok, socket} = start_socket()
     assert :connected == TestSocket.wait_connect_status(socket)
@@ -204,4 +214,11 @@ defmodule Phoenix.Channels.GenSocketClientTest do
   end
 
   defp query_params(), do: [{"shared_secret", "supersecret"}]
+
+  defp url_updated() do
+    "#{Endpoint.url()}/test_socket_updated/websocket"
+    |> String.replace(~r(http://), "ws://")
+    |> String.replace(~r(https://), "wss://")
+  end
+  defp query_params_updated(), do: [{"shared_secret", "supersecret_updated"}]
 end

--- a/test/socket_client_test.exs
+++ b/test/socket_client_test.exs
@@ -220,5 +220,6 @@ defmodule Phoenix.Channels.GenSocketClientTest do
     |> String.replace(~r(http://), "ws://")
     |> String.replace(~r(https://), "wss://")
   end
+
   defp query_params_updated(), do: [{"shared_secret", "supersecret_updated"}]
 end

--- a/test/support/test_site.ex
+++ b/test/support/test_site.ex
@@ -20,6 +20,7 @@ defmodule TestSite do
     use Phoenix.Endpoint, otp_app: :phoenix_gen_socket_client
 
     socket("/test_socket", TestSite.Socket)
+    socket("/test_socket_updated", TestSite.SocketUpdated)
 
     @doc false
     def init(:supervisor, config) do
@@ -48,6 +49,25 @@ defmodule TestSite do
     def connect(params, socket) do
       case params["shared_secret"] do
         "supersecret" -> {:ok, socket}
+        _ -> :error
+      end
+    end
+
+    def id(_socket), do: ""
+  end
+
+  defmodule SocketUpdated do
+    @moduledoc false
+    use Phoenix.Socket
+
+    transport(:websocket, Phoenix.Transports.WebSocket)
+
+    # List of exposed channels
+    channel("channel:*", TestSite.Channel)
+
+    def connect(params, socket) do
+      case params["shared_secret"] do
+        "supersecret_updated" -> {:ok, socket}
         _ -> :error
       end
     end


### PR DESCRIPTION
Add support for returning {:connect, url, query_params, state) from handle_info callbacks. This will allow the socket to connect to a different url and/or tokens/params that it was initially set up with.

Also updated tests and the readme documentation.

I did not add it to the changelist as you should pick what version number you want to call it.

Also tested calling it from the code I'm working on and it does what I need.