### PR TITLE
Fix reconnecting a socket that is already running to new url/params

### DIFF
--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -4,33 +4,37 @@
       name: "default",
       files: %{
         included:
-          case Mix.env do
+          case Mix.env() do
             :dev -> ["lib/"]
             :test -> ["test/"]
           end,
         excluded: []
       },
-      checks: [
-        {Credo.Check.Consistency.ExceptionNames},
-        {Credo.Check.Consistency.SpaceInParentheses},
-        {Credo.Check.Consistency.SpaceAroundOperators},
-        {Credo.Check.Consistency.TabsOrSpaces},
-        {Credo.Check.Design.AliasUsage, if_called_more_often_than: 2},
-        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, false},
-        {Credo.Check.Readability.PredicateFunctionNames},
-        {Credo.Check.Readability.TrailingBlankLine},
-        {Credo.Check.Readability.TrailingWhiteSpace},
-        {Credo.Check.Readability.MaxLineLength, max_length: 120},
-        {Credo.Check.Readability.VariableNames},
-        {Credo.Check.Warning.IExPry},
-        {Credo.Check.Warning.IoInspect}
-      ] ++ case Mix.env do
-        :dev ->
-          [
-            {Credo.Check.Readability.ModuleDoc}
-          ]
-        :test -> []
-      end
+      checks:
+        [
+          {Credo.Check.Consistency.ExceptionNames},
+          {Credo.Check.Consistency.SpaceInParentheses},
+          {Credo.Check.Consistency.SpaceAroundOperators},
+          {Credo.Check.Consistency.TabsOrSpaces},
+          {Credo.Check.Design.AliasUsage, if_called_more_often_than: 2},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, false},
+          {Credo.Check.Readability.PredicateFunctionNames},
+          {Credo.Check.Readability.TrailingBlankLine},
+          {Credo.Check.Readability.TrailingWhiteSpace},
+          {Credo.Check.Readability.MaxLineLength, max_length: 120},
+          {Credo.Check.Readability.VariableNames},
+          {Credo.Check.Warning.IExPry},
+          {Credo.Check.Warning.IoInspect}
+        ] ++
+          case Mix.env() do
+            :dev ->
+              [
+                {Credo.Check.Readability.ModuleDoc}
+              ]
+
+            :test ->
+              []
+          end
     }
   ]
 }

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -391,7 +391,7 @@ defmodule Phoenix.Channels.GenSocketClient do
     |> Enum.each(&Process.delete/1)
 
     if transport_mref, do: Process.demonitor(transport_mref, [:flush])
-    if transport_pid, do: Process.exit( transport_pid, :kill )
+    if transport_pid, do: Process.exit( transport_pid, :normal )
     %{state | transport_pid: nil, transport_mref: nil}
   end
 

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -394,7 +394,7 @@ defmodule Phoenix.Channels.GenSocketClient do
 
     if transport_mref, do: Process.demonitor(transport_mref, [:flush])
     # if transport_pid is running, exit it so as to not leak processes
-    if transport_pid, do: Process.exit( transport_pid, :normal )
+    if transport_pid, do: Process.exit(transport_pid, :normal)
     %{state | transport_pid: nil, transport_mref: nil}
   end
 

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -375,7 +375,8 @@ defmodule Phoenix.Channels.GenSocketClient do
     %{state | transport_pid: transport_pid, transport_mref: transport_mref}
   end
 
-  # reconnect
+  # reconnect - the transport_pid is already running (failed the above match)
+  # so now we need to reinit and try connecting again.
   defp connect(state) do
     state
     |> reinit()

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -375,6 +375,7 @@ defmodule Phoenix.Channels.GenSocketClient do
     %{state | transport_pid: transport_pid, transport_mref: transport_mref}
   end
 
+  # reconnect
   defp connect(state) do
     state
     |> reinit()
@@ -391,6 +392,7 @@ defmodule Phoenix.Channels.GenSocketClient do
     |> Enum.each(&Process.delete/1)
 
     if transport_mref, do: Process.demonitor(transport_mref, [:flush])
+    # if transport_pid is running, exit it so as to not leak processes
     if transport_pid, do: Process.exit( transport_pid, :normal )
     %{state | transport_pid: nil, transport_mref: nil}
   end

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -387,14 +387,14 @@ defmodule Phoenix.Channels.GenSocketClient do
 
   defp url(state), do: "#{state.url}?#{URI.encode_query(state.query_params)}"
 
-  defp reinit(%{transport_mref: transport_mref, transport_pid: transport_pid} = state) do
+  defp reinit(state) do
     Process.get_keys()
     |> Stream.filter(&match?({__MODULE__, _}, &1))
     |> Enum.each(&Process.delete/1)
 
-    if transport_mref, do: Process.demonitor(transport_mref, [:flush])
+    if state.transport_mref, do: Process.demonitor(state.transport_mref, [:flush])
     # if transport_pid is running, exit it so as to not leak processes
-    if transport_pid, do: Process.exit(transport_pid, :normal)
+    if state.transport_pid, do: Process.exit(state.transport_pid, :normal)
     %{state | transport_pid: nil, transport_mref: nil}
   end
 

--- a/test/socket_client_test.exs
+++ b/test/socket_client_test.exs
@@ -29,7 +29,6 @@ defmodule Phoenix.Channels.GenSocketClientTest do
     assert :connected == TestSocket.wait_connect_status(socket)
   end
 
-
   test "no auto connect" do
     assert {:ok, socket} = start_socket(url(), query_params(), false)
     refute :connected == TestSocket.wait_connect_status(socket, 100)

--- a/test/socket_client_test.exs
+++ b/test/socket_client_test.exs
@@ -20,6 +20,16 @@ defmodule Phoenix.Channels.GenSocketClientTest do
     assert {:ok, {"channel:1", %{}}} == TestSocket.join(socket, "channel:1")
   end
 
+  test "reconnect works" do
+    assert {:ok, socket} = start_socket()
+    assert :connected == TestSocket.wait_connect_status(socket)
+
+    # reconnect to a different url
+    :ok = TestSocket.connect(socket, url_updated(), query_params_updated())
+    assert :connected == TestSocket.wait_connect_status(socket)
+  end
+
+
   test "no auto connect" do
     assert {:ok, socket} = start_socket(url(), query_params(), false)
     refute :connected == TestSocket.wait_connect_status(socket, 100)


### PR DESCRIPTION
Ran into an issue when updating the connection an already running transport layer. Mainly, the connect/1 function failed to match if the incoming transport_pid was not nil (if it’s already running). This is important in the case where the client needs to migrate to a new server or update it's connection params.

First I added a second connect/1 function that resets the state, then calls connect again, with a nil transport_pid. This solves reconnecting with an already running transport pid.

Second, I modified reinit/1 so that if the transport_pid is set, it exits that transport process. This prevents process leakage as the connection is reset.

Third, I added a test case that would have caught this situation and now it passes.

Finally, I ran the Elixir formatter (v1.7), which touched quite a few lines in .credo.exs. Nothing functional changed.

I did not need to change any docs, as it didn’t add any functionality. Just fixed a bug.

Note: the docs fail to build under Elixir 1.7, but that is separate issue. You should update ex_doc to v0.19 or so.