### PR TITLE
`joined?/1` should be called from the GenSocketClient process

### DIFF
--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -4,33 +4,37 @@
       name: "default",
       files: %{
         included:
-          case Mix.env do
+          case Mix.env() do
             :dev -> ["lib/"]
             :test -> ["test/"]
           end,
         excluded: []
       },
-      checks: [
-        {Credo.Check.Consistency.ExceptionNames},
-        {Credo.Check.Consistency.SpaceInParentheses},
-        {Credo.Check.Consistency.SpaceAroundOperators},
-        {Credo.Check.Consistency.TabsOrSpaces},
-        {Credo.Check.Design.AliasUsage, if_called_more_often_than: 2},
-        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, false},
-        {Credo.Check.Readability.PredicateFunctionNames},
-        {Credo.Check.Readability.TrailingBlankLine},
-        {Credo.Check.Readability.TrailingWhiteSpace},
-        {Credo.Check.Readability.MaxLineLength, max_length: 120},
-        {Credo.Check.Readability.VariableNames},
-        {Credo.Check.Warning.IExPry},
-        {Credo.Check.Warning.IoInspect}
-      ] ++ case Mix.env do
-        :dev ->
-          [
-            {Credo.Check.Readability.ModuleDoc}
-          ]
-        :test -> []
-      end
+      checks:
+        [
+          {Credo.Check.Consistency.ExceptionNames},
+          {Credo.Check.Consistency.SpaceInParentheses},
+          {Credo.Check.Consistency.SpaceAroundOperators},
+          {Credo.Check.Consistency.TabsOrSpaces},
+          {Credo.Check.Design.AliasUsage, if_called_more_often_than: 2},
+          {Credo.Check.Readability.ParenthesesOnZeroArityDefs, false},
+          {Credo.Check.Readability.PredicateFunctionNames},
+          {Credo.Check.Readability.TrailingBlankLine},
+          {Credo.Check.Readability.TrailingWhiteSpace},
+          {Credo.Check.Readability.MaxLineLength, max_length: 120},
+          {Credo.Check.Readability.VariableNames},
+          {Credo.Check.Warning.IExPry},
+          {Credo.Check.Warning.IoInspect}
+        ] ++
+          case Mix.env() do
+            :dev ->
+              [
+                {Credo.Check.Readability.ModuleDoc}
+              ]
+
+            :test ->
+              []
+          end
     }
   ]
 }

--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -199,7 +199,7 @@ defmodule Phoenix.Channels.GenSocketClient do
   @doc """
   Returns true if the socket is joined on the given topic.
 
-  This function should be invoked from the `GenSocketClient` callback module.
+  This function should be invoked from the `GenSocketClient` process.
   """
   @spec joined?(topic) :: boolean
   def joined?(topic), do: not is_nil(join_ref(topic))


### PR DESCRIPTION
Currently it is documented that it should be called from the callback module, which is not the same thing.