### PR TITLE
Use Registry.start_link/1

### DIFF
--- a/test/support/test_site.ex
+++ b/test/support/test_site.ex
@@ -3,7 +3,7 @@ defmodule TestSite do
 
   defmodule PubSub do
     @moduledoc false
-    def start_link(), do: Registry.start_link(:duplicate, __MODULE__)
+    def start_link(), do: Registry.start_link(keys: :duplicate, name: __MODULE__)
 
     def subscribe(subscriber_key), do: Registry.register(__MODULE__, subscriber_key, nil)
 


### PR DESCRIPTION
`Registry.start_link/2` has been deprecated.