### PR TITLE
Streamline future releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   - mix compile --warnings-as-errors
   - MIX_ENV=test mix compile --warnings-as-errors
 script:
-  - MIX_ENV=docs mix docs
+  - mix docs
   - mix credo --strict
   - MIX_ENV=test mix credo --strict
   - mix test

--- a/mix.exs
+++ b/mix.exs
@@ -20,8 +20,7 @@ defmodule Phoenix.GenSocketClient.Mixfile do
         source_ref: "v#{@version}",
         main: "readme",
         extras: ["README.md"]
-      ],
-      preferred_cli_env: [docs: :docs]
+      ]
     ]
   end
 
@@ -40,7 +39,7 @@ defmodule Phoenix.GenSocketClient.Mixfile do
       {:cowboy, "~> 1.0", only: :test},
       {:credo, "~> 0.8.10", only: [:dev, :test], runtime: false},
       {:dialyze, "~> 0.2.1", only: :dev},
-      {:ex_doc, "~> 0.22.1", only: :docs}
+      {:ex_doc, "~> 0.22.1", only: :dev, runtime: false}
     ]
   end
 


### PR DESCRIPTION
Doc generation was limited to the doc
environment. This made making a release
somewhat unergonomic since it itself
also had to be done in the docs environment.