### PR TITLE
Fix call/3 function spec

### DIFF
--- a/lib/gen_socket_client.ex
+++ b/lib/gen_socket_client.ex
@@ -156,7 +156,7 @@ defmodule Phoenix.Channels.GenSocketClient do
   end
 
   @doc "Makes a synchronous call to the server and waits for its reply."
-  @spec call(GenServer.server(), any, non_neg_integer) :: any
+  @spec call(GenServer.server(), any, timeout) :: any
   def call(server, request, timeout \\ 5000),
     do: GenServer.call(server, {__MODULE__, :call, request}, timeout)
 


### PR DESCRIPTION
Since GenSocketClient.call/3 has the same signature of
GenServer.call/3, make the specs coincident. This change prevents type
checking tools (such as dialyzex) from raising errors due to the fact
that `:infinity` breaks the contract.