### PR TITLE
Fix serializer format to text in order to support Phoenix 1.5.7

### DIFF
--- a/lib/gen_socket_client/serializer.ex
+++ b/lib/gen_socket_client/serializer.ex
@@ -27,7 +27,7 @@ defmodule Phoenix.Channels.GenSocketClient.Serializer.Json do
   @doc false
   def encode_message(message) do
     case Jason.encode(message) do
-      {:ok, encoded} -> {:ok, {:binary, encoded}}
+      {:ok, encoded} -> {:ok, {:text, encoded}}
       error -> error
     end
   end


### PR DESCRIPTION
Should also work with older versions of Phoenix, since they do not respecting message format and only one format was supported in all cases

I'm using this fork for now, to solve an issue mentioned here - https://github.com/Aircloak/phoenix_gen_socket_client/issues/54

Please take a look if you are happy with it